### PR TITLE
Add more DMG Media to the list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 		"128": "icons/icon128.png"
 	},
 	"manifest_version": 2,
-	"description": "Blocks dailymail.co.uk links, because you don't need that rubbish in your life.",
+	"description": "Blocks dailymail.co.uk and other DMG Media links, because you don't need that rubbish in your life.",
 	"content_scripts": [
 		{
 			"matches": [
@@ -16,7 +16,21 @@
 				"*://mailonsunday.co.uk/*",
 				"*://*.mailonsunday.co.uk/*",
 				"*://mymail.co.uk/*",
-				"*://*.mymail.co.uk/*"
+				"*://*.mymail.co.uk/*",
+                                "*://thisismoney.co.uk/*",
+                                "*://*.thisismoney.co.uk/*",
+                                "*://metro.co.uk/*",
+                                "*://*.metro.co.uk/*",
+                                "*://wowcher.co.uk/*",
+                                "*://*.wowcher.co.uk/*",
+                                "*://jobsite.co.uk/*",
+                                "*://*.jobsite.co.uk/*",
+                                "*://zoopla.co.uk/*",
+                                "*://*.zoopla.co.uk/*",
+                                "*://primelocation.com/*",
+                                "*://www.primelocation.com/*",
+                                "*://jobrapido.com/*",
+                                "*://*.jobrapido.com/*"
 			],
 			"js": [
 				"script.js"


### PR DESCRIPTION
I've added some more DMG Media sites to your excellent Daily Mail Blocker. Feel free to accept or reject as appropriate.

If you'd prefer to reject and keep your blocker focused on just the Daily Mail sites, I'll be happy to fork and create a more generic "DMG Media" blocker. 